### PR TITLE
Prepare release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.0
+
 - Initial release of the `cobalt-async` crate.
 - Added the `apply_chunker()` function.


### PR DESCRIPTION
## What

Updates the CHANGELOG.md in preparation of the initial release.

## Why

We're ready to ship 🚀
