### PR TITLE
Prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.2.0
+
  - Added the `try_apply_chunker()` function.
 
 ## 0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-async"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of helpful functions for working with async Rust."


### PR DESCRIPTION
## What

Updates the version and changelog for the `0.2.0` release.

## Why

This release adds the `try_apply_chunker()` function, which greatly simplifies writing chunkers for `TryStream`s.
