### PR TITLE
feat/sink-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added checksum module with CRC32Sink to calculate CRC32.
+
 ## 0.3.0
 
 - Added a `try_finally` helper for running async cleanup code at the end of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Added checksum module with CRC32Sink to calculate CRC32.
+- Added counter module with ByteCounter and ByteLimit.
+- Enable optional features generation on docs.rs.
 
 ## 0.3.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,16 @@ include = [
     "LICENCE",
 ]
 
+[features]
+full = ["checksum"]
+
+checksum = ["crc32fast", "pin-project-lite", "anyhow"]
+
 [dependencies]
+anyhow = { version = "1.0.66", optional = true }
+crc32fast = { version = "1.3.2", optional=true }
 futures = "0.3.25"
+pin-project-lite = { version = "0.2.9", optional=true }
 
 [dev-dependencies]
 anyhow = "1.0.66"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,26 @@ include = [
 ]
 
 [features]
+# No features on by default
+default = []
+
+# Shorthand for enabling everything
 full = ["checksum"]
 
-checksum = ["crc32fast", "pin-project-lite", "anyhow"]
+checksum = ["crc32fast", "anyhow"]
 
 [dependencies]
 anyhow = { version = "1.0.66", optional = true }
 crc32fast = { version = "1.3.2", optional=true }
 futures = "0.3.25"
-pin-project-lite = { version = "0.2.9", optional=true }
+pin-project-lite = "0.2.9"
 
 [dev-dependencies]
 anyhow = "1.0.66"
 tokio = { version = "1.22.0", features=["macros"] }
 tokio-test = "0.4.2"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
 
   cargo:
-    image: harrisonai/rust:1.60-0.2
+    image: harrisonai/rust:1.65
     entrypoint: cargo
     volumes:
       - '~/.cargo/registry:/usr/local/cargo/registry'

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,0 +1,205 @@
+//! Module for checksum calculation.
+
+use std::marker::PhantomData;
+use std::task::Poll;
+
+use crc32fast::Hasher;
+use futures::prelude::*;
+use pin_project_lite::pin_project;
+use std::pin::Pin;
+use std::task::Context;
+
+pin_project! {
+#[must_use = "sinks do nothing unless polled"]
+/// A [Sink] that will calculate the CRC32 of any
+/// `AsRef<[u8]>`.
+///
+/// ```rust
+/// # use cobalt_async::checksum::CRC32Sink;
+/// # use futures::sink::SinkExt;
+/// # use tokio_test;
+/// # tokio_test::block_on(async {
+///      let mut sink = CRC32Sink::default();
+///      sink.send("this is a test".as_bytes()).await?;
+///      sink.close().await.unwrap();
+///      assert_eq!(220129258, sink.value().unwrap());
+///      # Ok::<(), anyhow::Error>(())
+/// # });
+///
+/// ```
+/// Attempting to get the [value](`CRC32Sink::value`) of the [Sink] before
+/// calling [Sink::poll_close] results in a [None] being returned
+/// ```rust
+/// # use cobalt_async::checksum::CRC32Sink;
+/// # use futures::sink::SinkExt;
+/// # use tokio_test;
+/// # tokio_test::block_on(async {
+///      let mut sink = CRC32Sink::default();
+///      sink.send("this is a test".as_bytes()).await?;
+///      assert!(sink.value().is_none());
+///      # Ok::<(), anyhow::Error>(())
+/// # });
+///
+pub struct CRC32Sink<Item: AsRef<[u8]>> {
+    digest: Option<Hasher>,
+    value: Option<u32>,
+    //Needed to allow StreamExt to determine the type of Item
+    marker:  std::marker::PhantomData<Item>
+}
+}
+
+impl<Item: AsRef<[u8]>> CRC32Sink<Item> {
+    /// Produces a new CRC32Sink.
+    pub fn new() -> CRC32Sink<Item> {
+        CRC32Sink {
+            digest: Some(Hasher::new()),
+            value: None,
+            marker: PhantomData,
+        }
+    }
+
+    /// Returns the crc32 of the values passed into the
+    /// [Sink] once the [Sink] has been closed.
+    pub fn value(&self) -> Option<u32> {
+        self.value
+    }
+}
+
+impl<Item: AsRef<[u8]>> Default for CRC32Sink<Item> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The [futures] crate provides a [into_sink](futures::io::AsyncWriteExt::into_sink) for AsyncWrite but it is
+/// not possible to get the value out of it afterwards as it takes ownership.
+impl<Item: AsRef<[u8]>> futures::sink::Sink<Item> for CRC32Sink<Item> {
+    type Error = anyhow::Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        match self.digest {
+            Some(_) => Poll::Ready(Ok(())),
+            None => Poll::Ready(Err(anyhow::Error::msg("Close has been called."))),
+        }
+    }
+
+    fn start_send(
+        self: Pin<&mut CRC32Sink<Item>>,
+        item: Item,
+    ) -> std::result::Result<(), Self::Error> {
+        let mut this = self.project();
+        match &mut this.digest {
+            Some(digest) => {
+                digest.update(item.as_ref());
+                Ok(())
+            }
+            None => Err(anyhow::Error::msg("Close has been called.")),
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        match self.digest {
+            Some(_) => Poll::Ready(Ok(())),
+            None => Poll::Ready(Err(anyhow::Error::msg("Close has been called."))),
+        }
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut CRC32Sink<Item>>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        match std::mem::take(&mut self.digest) {
+            Some(digest) => {
+                self.value = Some(digest.finalize());
+                Poll::Ready(Ok(()))
+            }
+            None => Poll::Ready(Err(anyhow::Error::msg("Close has been called."))),
+        }
+    }
+}
+
+impl AsyncWrite for CRC32Sink<&[u8]> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let mut this = self.project();
+        match &mut this.digest {
+            Some(digest) => {
+                digest.update(buf);
+                Poll::Ready(Ok(buf.len()))
+            }
+            None => Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Close has been called",
+            ))),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let mut this = self.project();
+        match &mut this.digest {
+            Some(_) => Poll::Ready(Ok(())),
+            None => Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Close has been called",
+            ))),
+        }
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match std::mem::take(&mut self.digest) {
+            Some(digest) => {
+                self.value = Some(digest.finalize());
+                Poll::Ready(Ok(()))
+            }
+            None => Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Close has been called",
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_crc32() {
+        let mut sink = CRC32Sink::default();
+        sink.send(&[0, 100]).await.unwrap();
+        sink.close().await.unwrap();
+        assert_eq!(184989630, sink.value.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_crc32_write_after_close() {
+        let mut sink = CRC32Sink::default();
+        sink.send(&[0, 100]).await.unwrap();
+        sink.close().await.unwrap();
+        assert!(sink.send(&[0, 100]).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_crc32_flush_after_close() {
+        let mut sink = CRC32Sink::default();
+        sink.send(&[0, 100]).await.unwrap();
+        sink.close().await.unwrap();
+        assert!(sink.flush().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_crc32_close_after_close() {
+        let mut sink = CRC32Sink::<&[u8]>::default();
+        futures::SinkExt::close(&mut sink).await.unwrap();
+        assert!(futures::SinkExt::close(&mut sink).await.is_err());
+    }
+}

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,0 +1,200 @@
+//! Module holding utilities related to counts
+//! of bytes passed to [AsyncWrite].
+
+use std::task::Poll;
+
+use futures::ready;
+use futures::AsyncWrite;
+use pin_project_lite::pin_project;
+use std::io::{Error, ErrorKind, Result};
+use std::pin::Pin;
+use std::task::Context;
+
+pin_project! {
+    ///An [AsyncWrite] which counts bytes written to the
+    ///wrapped [AsyncWrite].
+    ///```rust
+    /// # use cobalt_async::counter::ByteCounter;
+    /// # use futures::AsyncWriteExt;
+    /// # use futures::io::sink;
+    /// # use tokio_test;
+    /// # tokio_test::block_on(async {
+    ///      let mut counter = ByteCounter::new(sink());
+    ///      counter.write("this is a test".as_bytes()).await?;
+    ///      assert_eq!(14, counter.byte_count());
+    ///      # Ok::<(), anyhow::Error>(())
+    /// # });
+    ///````
+    ///
+    ///## Note
+    ///The count is stored as a [u128] and unchecked addition
+    ///is use to increment the count which means wrapping a
+    ///long running [AsyncWrite] may lead to an overflow.
+    #[derive(Debug)]
+    pub struct ByteCounter<T:AsyncWrite> {
+        byte_count: u128,
+        #[pin]
+        inner: T
+    }
+}
+
+impl<T: AsyncWrite> ByteCounter<T> {
+    /// Returns a new ByteCounter
+    /// wrapping the inner [AsyncWrite], with
+    /// the byte count initialised to 0.
+    pub fn new(inner: T) -> Self {
+        ByteCounter {
+            byte_count: 0,
+            inner,
+        }
+    }
+
+    /// Returns the current count of bytes
+    /// written into the [AsyncWrite].
+    pub fn byte_count(&self) -> u128 {
+        self.byte_count
+    }
+
+    /// Returns the inner [AsyncWrite], consuming
+    /// this [Self].
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T: AsyncWrite> AsyncWrite for ByteCounter<T> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        let this = self.project();
+        let written = ready!(this.inner.poll_write(cx, buf))?;
+        *this.byte_count += u128::try_from(written).map_err(|e| Error::new(ErrorKind::Other, e))?;
+        Poll::Ready(Ok(written))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.project().inner.poll_close(cx)
+    }
+}
+
+pin_project! {
+    ///An AyncWrite which raises an Error if the number of bytes
+    ///written is more that the `byte_limit`
+    ///```rust
+    /// # use cobalt_async::counter::ByteLimit;
+    /// # use futures::AsyncWriteExt;
+    /// # use futures::io::sink;
+    /// # use tokio_test;
+    /// # tokio_test::block_on(async {
+    ///      let mut counter = ByteLimit::new_from_inner(sink(), 10);
+    ///      counter.write("this is a ".as_bytes()).await?;
+    ///      assert!(counter.write("error".as_bytes()).await.is_err());
+    ///      # Ok::<(), anyhow::Error>(())
+    /// # });
+    ///````
+    ///
+    ///## Note
+    ///The count is stored as a [u128] and unchecked addition
+    ///is use to increment the count which means wrapping a
+    ///long running [AsyncWrite] may lead to an overflow.
+    #[derive(Debug)]
+    pub struct ByteLimit<T:AsyncWrite> {
+        byte_limit: u128,
+        #[pin]
+        counter: ByteCounter<T>
+    }
+}
+
+impl<T: AsyncWrite> ByteLimit<T> {
+    /// Creates a new [ByteLimit] using the provided [ByteCounter]
+    /// which will raise an error when the `byte_limit` is exceeded.
+    pub fn new(counter: ByteCounter<T>, byte_limit: u128) -> Self {
+        ByteLimit {
+            byte_limit,
+            counter,
+        }
+    }
+
+    /// Convenience method to create a `ByteLimit` and `ByteCounter`
+    /// from the inner `AsyncWrite`.
+    pub fn new_from_inner(inner: T, byte_limit: u128) -> Self {
+        ByteLimit {
+            byte_limit,
+            counter: ByteCounter::new(inner),
+        }
+    }
+
+    /// Returns the inner [ByteCounter] consuming the [Self].
+    pub fn into_innner(self) -> ByteCounter<T> {
+        self.counter
+    }
+}
+
+impl<T: AsyncWrite> AsyncWrite for ByteLimit<T> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        let this = self.project();
+        let current_count = this.counter.byte_count();
+        match this.counter.poll_write(cx, buf)? {
+            Poll::Ready(written) => {
+                let written_u128 =
+                    u128::try_from(written).map_err(|e| Error::new(ErrorKind::Other, e))?;
+                if current_count + written_u128 > *this.byte_limit {
+                    Poll::Ready(Err(Error::new(
+                        ErrorKind::Other,
+                        "Byte Limit Reached: {this.byte_limit} bytes",
+                    )))
+                } else {
+                    Poll::Ready(Ok(written))
+                }
+            }
+            _ => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.project().counter.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.project().counter.poll_close(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::prelude::*;
+
+    #[tokio::test]
+    async fn test_byte_count() {
+        let buffer = vec![];
+        let mut counter = ByteCounter::new(buffer);
+        let bytes_to_write = 100_usize;
+        assert!(counter.write_all(&vec![0; bytes_to_write]).await.is_ok());
+        counter.close().await.unwrap();
+        assert_eq!(
+            u128::try_from(bytes_to_write).unwrap(),
+            counter.byte_count()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_byte_count_limit_over() {
+        let buffer = vec![];
+        let mut counter = ByteLimit::new_from_inner(buffer, 99);
+        let bytes_to_write = 100_usize;
+        assert!(counter.write_all(&vec![0; bytes_to_write]).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_byte_count_limit_reached() {
+        let buffer = vec![];
+        let mut counter = ByteLimit::new_from_inner(buffer, 100);
+        let bytes_to_write = 100_usize;
+        assert!(counter.write_all(&vec![0; bytes_to_write]).await.is_ok());
+        let counter = counter.into_innner();
+        assert_eq!(counter.byte_count(), bytes_to_write as u128);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 //! ventures and ultimately improve the standard of healthcare for 1 million lives every day.
 //!
 
+#[cfg(feature = "checksum")]
+pub mod checksum;
 mod chunker;
 mod try_finally;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,13 @@
 //! At [harrison.ai](https://harrison.ai) our mission is to create AI-as-a-medical-device solutions through
 //! ventures and ultimately improve the standard of healthcare for 1 million lives every day.
 //!
-
+//!
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "checksum")]
+#[cfg_attr(docsrs, doc(cfg(feature = "checksum")))]
 pub mod checksum;
 mod chunker;
+pub mod counter;
 mod try_finally;
 
 pub use chunker::{apply_chunker, try_apply_chunker, ChunkResult};


### PR DESCRIPTION
## What

Added `checksum` and `counter` modules.

### `checksum`

Calculates crc32 checksum from bytes written into `Sink` or `AsyncWrite`.  This module is feature
guarded behind a `checksum` feature flag to try and keep compile times in check.

### `counter`

Introduced `ByteCounter` and `ByteLimit`.  `ByteCounter` wraps a `AsyncWrite` and counts the bytes
written into it. `ByteLimit` ensures that the number of bytes written into the `AsyncWrite` does not exceed the configured limit.

## Why

These utilities are small reusable components which will be useful in other projects.

## Notes

Building the docs locally, with all optional features as per `docs.rs` needs the command

```bash
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```
